### PR TITLE
prompt needs to chomp so strings don't have \n in them

### DIFF
--- a/run_me.rb
+++ b/run_me.rb
@@ -14,9 +14,15 @@ def run_command(command)
   `#{command}`
 end
 
-def prompt(string,default="")
+def prompt(string,default=nil)
+  string = "#{string} (#{default})" unless default.nil?
   puts string
-  gets.chomp
+  val = gets.chomp
+  if val.empty?
+    return default
+  else
+    return val
+  end
 end
 
 # github_repo = prompt "What is the github repo for the new app?"


### PR DESCRIPTION
```
[20:17:35][ruxton@cyclops:rails-template] $ irb
2.0.0-p451 :001 > gets
sdfsdf
 => "sdfsdf\n"
2.0.0-p451 :002 > gets.chomp
sdfsdf
 => "sdfsdf"
```
