### PR TITLE
As an admin, I can see a list of admins, or a list of members

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,12 +2,12 @@ class Admin::UsersController < Admin::BaseController
 
   def index
     authorize(User)
-    @users = User.member.page(params[:page])
+    @users = policy_scope(User.member).page(params[:page])
   end
 
   def index_admins
     authorize(User)
-    @users = User.admin.page(params[:page])
+    @users = policy_scope(User.admin).page(params[:page])
     render :index
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,13 @@ class Admin::UsersController < Admin::BaseController
 
   def index
     authorize(User)
-    @users = User.all.page(params[:page])
+    @users = User.member.page(params[:page])
+  end
+
+  def index_admins
+    authorize(User)
+    @users = User.admin.page(params[:page])
+    render :index
   end
 
   def new

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,9 @@
+module Admin::UsersHelper
+
+  def users_index_tab_for(label, path)
+    classes = ""
+    classes = "active" if request.path == path
+    content_tag(:li, class: classes) { link_to(label, path) }
+  end
+
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -21,6 +21,7 @@ class UserPolicy < ApplicationPolicy
 # CRUD
 
   alias :index? :is_admin?
+  alias :index_admins? :is_admin?
   alias :new? :is_admin?
   alias :create? :is_admin?
   alias :destroy? :is_admin?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,20 @@
 class UserPolicy < ApplicationPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if user.present? && (user.admin? || user.member?)
+        scope
+      else
+        scope.none
+      end
+    end
+  end
 
   def permitted_attributes
     if is_admin?

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -3,20 +3,18 @@
 %p= link_to "Add new User", new_admin_user_path, class: "button"
 
 %ul.tabs
-  %li.active= link_to "Active Tab", admin_users_path
-  %li= link_to "Inactive Tab", admin_users_path
+  = users_index_tab_for "Members", admin_users_path
+  = users_index_tab_for "Admins", admins_admin_users_path
 
 %table
   %thead
     %tr
       %th Email
-      %th Role
       %th.actions Actions
   %tbody
     - @users.each do |user|
       %tr
         %td= user.email
-        %td= user.role.titleize
         %td.actions
           = link_to "Edit", edit_admin_user_path(user), class: "button"
           = link_to "Delete", admin_user_path(user), method: :delete, data: { confirm: "Are you sure you want to delete #{user}?" }, class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,12 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :dashboard, only: :index
-    resources :users
+    resources :users do
+      collection do
+        # admins/users/admins
+        get "admins", action: :index_admins
+      end
+    end
   end
 
   namespace :member do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -8,7 +8,7 @@ describe Admin::UsersController do
     authenticated_as(:admin) do
       it { should be_success }
 
-      describe "populating @users" do
+      describe_assign(:users) do
         subject(:users) { get_index; assigns(:users) }
 
         it { should include(FactoryGirl.create(:user, :member)) }
@@ -26,7 +26,7 @@ describe Admin::UsersController do
     authenticated_as(:admin) do
       it { should be_success }
 
-      describe "populating @users" do
+      describe_assign(:users) do
         subject(:users) { get_index; assigns(:users) }
 
         it { should include(FactoryGirl.create(:user, :admin)) }

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -3,10 +3,35 @@ require 'spec_helper'
 describe Admin::UsersController do
 
   describe 'GET index' do
-    subject { get :index }
+    subject(:get_index) { get :index }
 
     authenticated_as(:admin) do
       it { should be_success }
+
+      describe "populating @users" do
+        subject(:users) { get_index; assigns(:users) }
+
+        it { should include(FactoryGirl.create(:user, :member)) }
+        it { should_not include(FactoryGirl.create(:user, :admin)) }
+      end
+    end
+
+    it_behaves_like "action requiring authentication"
+    it_behaves_like "action authorizes roles", [:admin]
+  end
+
+  describe 'GET index_admins' do
+    subject(:get_index) { get :index_admins }
+
+    authenticated_as(:admin) do
+      it { should be_success }
+
+      describe "populating @users" do
+        subject(:users) { get_index; assigns(:users) }
+
+        it { should include(FactoryGirl.create(:user, :admin)) }
+        it { should_not include(FactoryGirl.create(:user, :member)) }
+      end
     end
 
     it_behaves_like "action requiring authentication"

--- a/spec/features/admin/users/admin_index_users_spec.rb
+++ b/spec/features/admin/users/admin_index_users_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+feature 'Admin can view an index of users' do
+
+  sign_in_as(:admin)
+  let!(:member) { FactoryGirl.create(:user, :member) }
+
+  before do
+    click_header_option("Dashboard")
+    click_sidemenu_option("Users")
+  end
+
+  scenario "Using tabs to show different types of users" do
+    # By default, show only members
+    within("table") do
+      expect(page).to have_content(member.email)
+      expect(page).not_to have_content(current_user.email)
+    end
+
+    click_link("Admins")
+    within("table") do
+      expect(page).not_to have_content(member.email)
+      expect(page).to have_content(current_user.email)
+    end
+  end
+
+end

--- a/spec/helpers/admin/users_helper_spec.rb
+++ b/spec/helpers/admin/users_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Admin::UsersHelper do
+
+  describe "#users_index_tab_for" do
+    subject { helper.users_index_tab_for(label, path) }
+    let(:label) { "Jordan Rules!" }
+    let(:path)  { "dong_where_is_my_automobile" }
+
+    before do
+      stub_request = Object.new
+      allow(stub_request).to receive(:path).and_return(current_path)
+      allow(helper).to receive(:request).and_return(stub_request)
+    end
+
+    context "when the the current request's path is the same as the path passed through" do
+      let(:current_path) { path }
+      it { should include("<li class=\"active\"") }
+      it { should include("<a href=\"#{path}\"") }
+      it { should include(">#{label}</a>") }
+    end
+
+    context "when the the current request's path is not the same as the path passed through" do
+      let(:current_path) { File.join(path, "other_part") }
+      it { should_not include("<li class=\"active\"") }
+      it { should include("<a href=\"#{path}\"") }
+      it { should include(">#{label}</a>") }
+    end
+  end
+
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -18,6 +18,7 @@ describe UserPolicy do
 
     # CRUD actions
     it { should_not permit_access_to(:index) }
+    it { should_not permit_access_to(:index_admins) }
     it { should_not permit_access_to(:new) }
     it { should_not permit_access_to(:create) }
     it { should_not permit_access_to(:edit) }
@@ -40,6 +41,7 @@ describe UserPolicy do
 
     # CRUD actions
     it { should permit_access_to(:index) }
+    it { should permit_access_to(:index_admins) }
     it { should permit_access_to(:new) }
     it { should permit_access_to(:create) }
     it { should permit_access_to(:edit) }
@@ -62,6 +64,7 @@ describe UserPolicy do
 
     # CRUD actions
     it { should_not permit_access_to(:index) }
+    it { should_not permit_access_to(:index_admins) }
     it { should_not permit_access_to(:new) }
     it { should_not permit_access_to(:create) }
     describe "update?" do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -5,6 +5,37 @@ describe UserPolicy do
   let(:policy) { UserPolicy.new(user, target_user) }
   let(:target_user) { user }
 
+  describe UserPolicy::Scope do
+    let(:policy_scope) { UserPolicy::Scope.new(user, scope) }
+    let(:scope) { User.all }
+
+    describe "#resolve" do
+      subject { policy_scope.resolve }
+
+      context "for an anonymous user" do
+        let(:user) { nil }
+
+        it "cannot see any users" do
+          should be_empty
+        end
+      end
+
+      context "for an admin" do
+        let(:user) { FactoryGirl.build(:user, :admin) }
+
+        it { should include(FactoryGirl.create(:user, :admin)) }
+        it { should include(FactoryGirl.create(:user, :member)) }
+      end
+
+      context "for a member" do
+        let(:user) { FactoryGirl.build(:user, :member) }
+
+        it { should include(FactoryGirl.create(:user, :admin)) }
+        it { should include(FactoryGirl.create(:user, :member)) }
+      end
+    end
+  end
+
   context "for an anonymous user" do
     let(:user) { nil }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   # Controllers
   config.include Devise::TestHelpers, type: :controller
   config.extend ControllerAuthenticationSupport, type: :controller
+  config.extend ControllerDescribeAssignsHelper, type: :controller
 
   # Features
   config.include FeatureHelper, type: :feature

--- a/spec/support/controller_describe_assigns_helper.rb
+++ b/spec/support/controller_describe_assigns_helper.rb
@@ -1,0 +1,22 @@
+module ControllerDescribeAssignsHelper
+  def describe_assign(var_name, options={}, &block)
+    describe "@#{var_name}" do
+
+      # Mangle the name of subject in such a way that we are very unlikely to change
+      # what it is. Object ID returns the unique ID of the current object. In this case the
+      # class which defines the current example group.
+      mangled_subject = "#{object_id}_subject"
+      alias_method(mangled_subject, :subject)
+
+      options[:as] ||= var_name unless instance_methods.include?(var_name.to_sym)
+      options[:as] ||= "#{object_id}_imp_subject"
+
+      subject(options[:as]) do
+        __send__(mangled_subject)
+        assigns[var_name]
+      end
+
+      instance_eval &block
+    end
+  end
+end


### PR DESCRIPTION
This is part of some work I'm doing for El Mulcho.

Adds tabs that switch between roles on the admin users interface

By default show members, much more likely an admin is gwan interfere with a member user

![screen shot 2015-05-18 at 5 00 01 pm](https://cloud.githubusercontent.com/assets/296341/7693836/72b46cfa-fe0a-11e4-98ad-a6a80809020a.png)

Here's dat admins

![screen shot 2015-05-18 at 5 00 05 pm](https://cloud.githubusercontent.com/assets/296341/7693842/82f6db20-fe0a-11e4-8b02-f8f036b1e4e9.png)

I have removed the role field from the index page since the screenshots were taken
