### PR TITLE
DRY controlles by moving sort method to admin::base

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,4 +3,12 @@ class Admin::BaseController < ApplicationController
   after_action :verify_authorized
 
   layout "admin/layout"
+
+protected
+
+  def sort(collection)
+    # Sort by :id by default, so there is a consistent order even when no order has been
+    # selected via the interface
+    ModelSorter.sort(collection, params, {id: :desc})
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,10 +50,6 @@ private
     User.find(params[:id])
   end
 
-  def sort(collection)
-    ModelSorter.sort(collection, params)
-  end
-
   def user_form_attributes(user)
     params.require(:user).permit(policy(user).permitted_attributes).tap do |attributes|
       attributes[:user].delete(:password) if attributes[:user].present? && attributes[:user][:password].blank?

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -18,7 +18,7 @@ describe Admin::UsersController do
 
         describe "sorting" do
           it "sorts by query parameters" do
-            expect(ModelSorter).to receive(:sort).with(instance_of(User::ActiveRecord_Relation), anything).and_call_original
+            expect(ModelSorter).to receive(:sort).with(instance_of(User::ActiveRecord_Relation), anything, {id: :desc}).and_call_original
             subject
           end
         end
@@ -45,7 +45,7 @@ describe Admin::UsersController do
 
         describe "sorting" do
           it "sorts by query parameters" do
-            expect(ModelSorter).to receive(:sort).with(instance_of(User::ActiveRecord_Relation), anything).and_call_original
+            expect(ModelSorter).to receive(:sort).with(instance_of(User::ActiveRecord_Relation), anything, {id: :desc}).and_call_original
             subject
           end
         end


### PR DESCRIPTION
The `sort` method is gonna be pretty much the same for all other admin controllers, if for some reason you wanna customise it, just override it :)

Will change generators not to generate this piece of code anymore.