### PR TITLE
Adding handy capybara error tool

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,5 +3,9 @@ module Capybara
     def has_flash?(name, value=nil)
       has_css?(".flash.flash-#{name}", text: value)
     end
+
+    def has_error_message?(field, message)
+      has_css?(".#{field}.field_with_errors .error", text: message)
+    end
   end
 end


### PR DESCRIPTION
The helper allows you to do something like:

```ruby
expect(page).to have_error_message("item_title", "can't be blank")
```