### PR TITLE
Allow selection of options via an id

### DIFF
--- a/spec/support/feature_attributes_support.rb
+++ b/spec/support/feature_attributes_support.rb
@@ -12,7 +12,12 @@ module FeatureAttributesSupport
         field = find_field(field_name)
         case field.tag_name
         when "select"
-          field.select value
+          if value.is_a?(Fixnum)
+            text = field.find("option[value='#{value}']").text
+            field.select text
+          else
+            field.select value
+          end
         else
           field.set value
         end


### PR DESCRIPTION
capybara's select method only uses the name of an option.

This allows an id (EG: select Address id: 9)