### PR TITLE
Feature/101955804 more base global styles

### DIFF
--- a/app/assets/stylesheets/admin/global/_buttons.sass
+++ b/app/assets/stylesheets/admin/global/_buttons.sass
@@ -1,42 +1,6 @@
 .btn, %button
-  background-color: $action-color
-  border-radius: $border-radius
-  color: #fff
-  cursor: pointer
-  display: inline-block
-  font-family: $body-fonts
-  font-size: $body-font-size
-  font-weight: 600
-  line-height: 1
-  padding: 0.75em 1em
-  text-decoration: none
-  vertical-align: middle
-  white-space: nowrap
-  &:hover,
-  &:focus
-    background-color: darken($action-color, 15%)
-    color: #fff
-
-  &.disabled, &[disabled]
-    cursor: not-allowed
-    opacity: 0.5
-
   &.btn-small
     font-size: 0.7em
     padding: 0.3em 1em
     margin-left: 0.5em
     line-height: $body-line-height
-
-  &.btn-danger, &[data-method="delete"]
-    background-color: darken($negative-color, 50)
-    &:hover,
-    &:focus
-      background-color: darken($negative-color, 60)
-
-/// The below is only for buttons coming from the OS, not links that are made to look like buttons
-#{$all-buttons}
-  @extend %button
-  @include appearance(none)
-  -webkit-font-smoothing: antialiased
-  border: none
-  user-select: none

--- a/app/assets/stylesheets/admin/global/_flashes.sass
+++ b/app/assets/stylesheets/admin/global/_flashes.sass
@@ -1,15 +1,3 @@
-$flash-notice-color: $positive-color
-$flash-alert-color: $negative-color
-
-=flash($color)
-  background-color: $color
-  color: darken($color, 60%)
-  a
-    color: darken($color, 70%)
-    text-decoration: underline
-    &:focus, &:hover
-      color: darken($color, 90%)
-
 .flash-wrapper
   margin: 0 1em
 
@@ -17,16 +5,7 @@ $flash-alert-color: $negative-color
     margin: -1em 0 0
 
   .flash
-    display: block
-    font-weight: 600
     margin-bottom: $base-spacing
     padding: $small-spacing
-    text-align: center
-    &-notice
-      +flash($flash-notice-color)
-
-    &-alert
-      +flash($flash-alert-color)
-
     +media($medium-screen-down)
       padding: 0.75em 1em

--- a/app/assets/stylesheets/admin/global/_forms.sass
+++ b/app/assets/stylesheets/admin/global/_forms.sass
@@ -32,9 +32,6 @@ label,
 select
   font-size: $body-font-size
 
-label
-  margin-bottom: ($small-spacing / 2)
-
 textarea
   resize: vertical
 

--- a/app/assets/stylesheets/admin/global/_forms.sass
+++ b/app/assets/stylesheets/admin/global/_forms.sass
@@ -1,8 +1,3 @@
-$form-error-color: $negative-color
-$form-hint-color: whiten($brand-grey, 0.10)
-$form-box-shadow: inset 0 1px 3px rgba(#000, 0.06)
-$form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $lightness: -5%, $alpha: -0.3)
-
 form
   .input, .row
     margin-bottom: $small-spacing
@@ -25,57 +20,26 @@ fieldset
     +media($large-screen-down)
       padding: 0
 
-input,
-label,
-select
-  display: block
-  font-family: $body-fonts
-  font-size: $body-font-size
-
-label
-  font-weight: 600
-  margin-bottom: ($small-spacing / 2)
-  &.required::after
-    content: "*"
-
-  abbr
-    display: none
-
 #{$all-text-inputs},
 select[multiple=multiple],
 textarea
-  background-color: #fff
-  border: $border
-  border-radius: $border-radius
-  box-shadow: $form-box-shadow
-  box-sizing: border-box
-  font-family: $body-fonts
-  font-size: $body-font-size
   margin-bottom: ($base-spacing / 2)
   padding: ($base-spacing / 3)
-  transition: border-color
-  width: 100%
-  &:hover
-    border-color: darken($border-color, 10%)
+  font-size: $body-font-size
 
-  &:focus
-    border-color: $action-color
-    box-shadow: $form-box-shadow-focus
-    outline: none
+input,
+label,
+select
+  font-size: $body-font-size
 
-  .field_with_errors &
-    border-color: darken($form-error-color, 60)
+label
+  margin-bottom: ($small-spacing / 2)
 
 textarea
   resize: vertical
 
 input[type="search"]
-  @include appearance(none)
-
-input[type="checkbox"],
-input[type="radio"]
-  display: inline
-  margin-right: ($small-spacing / 2)
+  +appearance(none)
 
 input[type="file"]
   padding-bottom: $small-spacing

--- a/app/assets/stylesheets/global/_base.sass
+++ b/app/assets/stylesheets/global/_base.sass
@@ -8,7 +8,7 @@ a
   text-decoration: none
   +transition(color 150ms ease)
   &:hover
-    color: darken($link-color, 15%)
+    color: blacken($link-color, 0.15)
 
 thead, h1, h2, h3, h4, h5, h6
   color: $heading-color

--- a/app/assets/stylesheets/global/_buttons.sass
+++ b/app/assets/stylesheets/global/_buttons.sass
@@ -1,0 +1,33 @@
+.btn, %button
+  background-color: $btn-default-color
+  border-radius: $border-radius
+  color: #fff
+  cursor: pointer
+  display: inline-block
+  font: $btn-text
+  padding: 12px 25px
+  text-decoration: none
+  vertical-align: middle
+  white-space: nowrap
+  &:hover,
+  &:focus
+    background-color: blacken($btn-default-color, 0.15)
+    color: #fff
+
+  &.disabled, &[disabled]
+    cursor: not-allowed
+    opacity: 0.5
+
+  &.btn-danger, &[data-method="delete"]
+    background-color: blacken($btn-danger-color, 0.50)
+    &:hover,
+    &:focus
+      background-color: blacken($btn-danger-color, 0.60)
+
+/// The below is only for buttons coming from the OS, not links that are made to look like buttons
+#{$all-buttons}
+  @extend %button
+  @include appearance(none)
+  -webkit-font-smoothing: antialiased
+  border: none
+  user-select: none

--- a/app/assets/stylesheets/global/_flashes.sass
+++ b/app/assets/stylesheets/global/_flashes.sass
@@ -1,0 +1,22 @@
+$flash-notice-color: $positive-color
+$flash-alert-color: $negative-color
+
+=flash($flash-color)
+  background-color: $flash-color
+  color: blacken($flash-color, 0.6)
+  a
+    color: blacken($flash-color, 0.7)
+    text-decoration: underline
+    &:focus, &:hover
+      color: blacken($flash-color, 0.9)
+
+.flash-wrapper
+  .flash
+    display: block
+    font-weight: 600
+    text-align: center
+    &-notice
+      +flash($flash-notice-color)
+
+    &-alert
+      +flash($flash-alert-color)

--- a/app/assets/stylesheets/global/_forms.sass
+++ b/app/assets/stylesheets/global/_forms.sass
@@ -1,0 +1,40 @@
+input,
+label,
+select
+  display: block
+  font-family: $body-fonts
+
+label
+  font-weight: 600
+  &.required
+    &:after
+      content: "*"
+    abbr
+      display: none
+
+input[type="checkbox"],
+input[type="radio"]
+  display: inline
+  margin-right: 6px
+
+#{$all-text-inputs},
+select[multiple=multiple],
+textarea
+  background-color: #fff
+  border: 1px solid $input-border-color
+  border-radius: $border-radius
+  box-shadow: $form-box-shadow
+  box-sizing: border-box
+  font-family: $body-fonts
+  transition: border-color
+  width: 100%
+  &:hover
+    border-color: darken($border-color, 10%)
+
+  &:focus
+    border-color: $accent-color
+    box-shadow: $form-box-shadow-focus
+    outline: none
+
+  .field_with_errors &
+    border-color: darken($form-error-color, 60)

--- a/app/assets/stylesheets/global/_forms.sass
+++ b/app/assets/stylesheets/global/_forms.sass
@@ -6,6 +6,7 @@ select
 
 label
   font-weight: 600
+  margin-bottom: 5px
   &.required
     &:after
       content: "*"
@@ -29,7 +30,7 @@ textarea
   transition: border-color
   width: 100%
   &:hover
-    border-color: darken($border-color, 10%)
+    border-color: blacken($border-color, 0.10)
 
   &:focus
     border-color: $accent-color
@@ -37,4 +38,4 @@ textarea
     outline: none
 
   .field_with_errors &
-    border-color: darken($form-error-color, 60)
+    border-color: blacken($form-error-color, 0.60)

--- a/app/assets/stylesheets/lib/_variables.sass
+++ b/app/assets/stylesheets/lib/_variables.sass
@@ -36,5 +36,10 @@ $form-hint-color: whiten($brand-grey, 0.10)
 $form-box-shadow: inset 0 1px 1px black(0.07)
 $form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($accent-color, $lightness: -5%, $alpha: -0.3)
 
+// ----- Buttons -----
+$btn-text: 600 15px/1 $heading-fonts
+$btn-default-color: $accent-color
+$btn-danger-color: $negative-color
+
 // -----  Defaults  -----
 $duration: 250ms

--- a/app/assets/stylesheets/lib/_variables.sass
+++ b/app/assets/stylesheets/lib/_variables.sass
@@ -1,18 +1,19 @@
-/// Brand Colours
+// -----  Brand Colours  -----
 $brand-black: #333
 
-/// Brand Shades
+// -----  Brand Shades  -----
 $brand-grey: #999
 $brand-grey-light: #ddd
 $brand-grey-dark: #111
+$brand-black: #000
 
-/// App Colours that work with the Brand
+// -----  App Colours that work with the Brand  -----
 $negative-color: #fbe3e4
 $warning-color: #f68823
 $positive-color: #e6efc2
 $accent-color: #477dca
 
-/// Typography
+// -----  Typography  -----
 $body-font-size: 16px
 $body-line-height: 1.5
 $body-fonts: $helvetica
@@ -23,10 +24,17 @@ $heading-color: $brand-grey-dark
 
 $link-color: $accent-color
 
-/// Borders
+// -----  Borders  -----
 $border-color: $brand-grey-light
 $border: 1px solid $border-color
 $border-radius: 3px
+$input-border-color: $brand-grey
 
-/// Defaults
+// -----  Forms  -----
+$form-error-color: $negative-color
+$form-hint-color: whiten($brand-grey, 0.10)
+$form-box-shadow: inset 0 1px 1px black(0.07)
+$form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($accent-color, $lightness: -5%, $alpha: -0.3)
+
+// -----  Defaults  -----
 $duration: 250ms

--- a/app/assets/stylesheets/member.sass
+++ b/app/assets/stylesheets/member.sass
@@ -3,12 +3,12 @@
 @import "global"
 @import "core/common"
 
-// @import "core/members/lib/functions"
-// @import "core/members/lib/variables"
-// @import "core/members/lib/mixins"
-// @import "core/members/lib/extends"
+// @import "core/member/lib/functions"
+// @import "core/member/lib/variables"
+// @import "core/member/lib/mixins"
+// @import "core/member/lib/extends"
 
-// @import "core/members/global/**/*"
+// @import "core/member/global/**/*"
 // @import "core/member/modules/**/*"
 
 ////


### PR DESCRIPTION
Every thing looks the same. I've moved some basic styles from admin into global. So a frontend dev can add new styles into the app and have them carry over to admin but (hopefully) not break it

Global styles include...
*buttons
*forms
*flash messages