### PR TITLE
Refactor: Move after sign in path into own class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,14 +20,7 @@ protected
 
   # Provided by Devise
   def after_sign_in_path_for(resource)
-    user_policy = UserPolicy.new(resource, resource)
-    if user_policy.admin_dashboard?
-      admin_dashboard_index_path
-    elsif user_policy.member_dashboard?
-      member_dashboard_index_path
-    else
-      root_path
-    end
+    AfterSignInPath.new(resource).to_s
   end
 
 # Strong Parameters

--- a/lib/after_sign_in_path.rb
+++ b/lib/after_sign_in_path.rb
@@ -1,0 +1,23 @@
+class AfterSignInPath
+
+  include Rails.application.routes.url_helpers
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def to_s
+    if user.present?
+      if user.admin?
+        admin_dashboard_index_path
+      else
+        member_dashboard_index_path
+      end
+    else
+      root_path
+    end
+  end
+
+end

--- a/spec/lib/after_sign_in_path_spec.rb
+++ b/spec/lib/after_sign_in_path_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe AfterSignInPath do
+  include Rails.application.routes.url_helpers
+
+  let(:path) { AfterSignInPath.new(user) }
+
+  describe "#to_s" do
+    subject { path.to_s }
+
+    context "when admin" do
+      let(:user) { FactoryGirl.build(:user, :admin) }
+      it { should eq(admin_dashboard_index_path) }
+    end
+
+    context "when member" do
+      let(:user) { FactoryGirl.build(:user, :member) }
+      it { should eq(member_dashboard_index_path) }
+    end
+
+    context "when nil" do
+      let(:user) { nil }
+      it { should eq(root_path) }
+    end
+  end
+
+end


### PR DESCRIPTION
Break the after sign in path out into its own class so its easier to manage if it gets more complex.

This was an invaluable refactoring in Top Club so I figured I'd try it out here.