### PR TITLE
Fix specs that would fail intermittently

### DIFF
--- a/spec/controllers/admin/admins_controller_spec.rb
+++ b/spec/controllers/admin/admins_controller_spec.rb
@@ -77,9 +77,8 @@ RSpec.describe Admin::AdminsController do
         it "creates a User object with the given attributes" do
           create_user
 
-          user = User.order(:created_at).last
+          user = User.find_by(email: params[:email])
           expect(user).to be_present
-          expect(user).to have_attributes(params.slice(:email))
           expect(user).to be_admin
         end
 

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -96,9 +96,8 @@ RSpec.describe Admin::MembersController do
         it "creates a User object with the given attributes" do
           create_user
 
-          user = User.order(:created_at).last
+          user = User.find_by(email: params[:email])
           expect(user).to be_present
-          expect(user).to have_attributes(params.slice(:email))
           expect(user).to be_member
         end
 

--- a/spec/features/admin/admins/admin_create_admin_spec.rb
+++ b/spec/features/admin/admins/admin_create_admin_spec.rb
@@ -18,8 +18,8 @@ feature 'Admin can create a new User' do
       expect(current_path).to eq(admin_admins_path)
 
       # User should be saved
-      latest_user = User.order(:created_at).last
-      expect(latest_user.email).to eq("valid@example.com")
+      latest_user = User.find_by(email: "valid@example.com")
+      expect(latest_user).to be_present
       expect(latest_user).to be_admin
     end
 

--- a/spec/features/admin/admins/admin_update_admin_spec.rb
+++ b/spec/features/admin/admins/admin_update_admin_spec.rb
@@ -21,9 +21,7 @@ feature 'Admin can update an existing User' do
       expect(current_path).to eq(admin_admins_path)
 
       # User should be saved
-      latest_user = User.order(:created_at).last
-      expect(latest_user.email).to eq("valid@example.com")
-      expect(latest_user).to be_admin
+      expect(target_user.reload.email).to eq("valid@example.com")
     end
 
     scenario 'Admin updates user with invalid data' do

--- a/spec/features/admin/members/admin_create_member_spec.rb
+++ b/spec/features/admin/members/admin_create_member_spec.rb
@@ -18,8 +18,8 @@ feature 'Admin can create a new User' do
       expect(current_path).to eq(admin_members_path)
 
       # User should be saved
-      latest_user = User.order(:created_at).last
-      expect(latest_user.email).to eq("valid@example.com")
+      latest_user = User.find_by(email: "valid@example.com")
+      expect(latest_user).to be_present
       expect(latest_user).to be_member
     end
 

--- a/spec/features/admin/members/admin_update_member_spec.rb
+++ b/spec/features/admin/members/admin_update_member_spec.rb
@@ -21,9 +21,7 @@ feature 'Admin can update an existing User' do
       expect(current_path).to eq(admin_members_path)
 
       # User should be saved
-      latest_user = User.order(:created_at).last
-      expect(latest_user.email).to eq("valid@example.com")
-      expect(latest_user).to be_member
+      expect(target_user.reload.email).to eq("valid@example.com")
     end
 
     scenario 'Admin updates user with invalid data' do


### PR DESCRIPTION
These specs were breaking occasionally in CCIWA, so I've fixed them there and here.

They can fail because the specs run fast enough that the created_at time for the user we are creating and the user that is signed in is the same.

Now it finds the user by the email we used.