### PR TITLE
Implement a more easily customisable method of declaring scopes

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -1,7 +1,9 @@
 class Admin::AdminsController < Admin::UsersController
 
-  def user_role
-    "admin"
+protected
+
+  def users_scope
+    User.admin
   end
 
   def redirect_path

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,7 +1,9 @@
 class Admin::MembersController < Admin::UsersController
 
-  def user_role
-    "member"
+protected
+
+  def users_scope
+    User.member
   end
 
   def redirect_path

--- a/spec/controllers/admin/admins_controller_spec.rb
+++ b/spec/controllers/admin/admins_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Admin::AdminsController do
 
   describe 'GET edit' do
     subject { get :edit, id: target_user.id }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :admin) }
 
     authenticated_as(:admin) do
       it { should be_success }
@@ -110,7 +110,7 @@ RSpec.describe Admin::AdminsController do
   describe 'POST update' do
     subject(:update_user) { post :update, id: target_user.id, user: params }
     let(:params) { {} }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :admin) }
 
     authenticated_as(:admin) do
 
@@ -153,7 +153,7 @@ RSpec.describe Admin::AdminsController do
 
   describe 'DELETE destroy' do
     subject { delete :destroy, id: target_user.id }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :admin) }
 
     authenticated_as(:admin) do
       it "deletes the user" do

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Admin::MembersController do
 
   describe 'GET edit' do
     subject { get :edit, id: target_user.id }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :member) }
 
     authenticated_as(:admin) do
       it { should be_success }
@@ -129,7 +129,7 @@ RSpec.describe Admin::MembersController do
   describe 'POST update' do
     subject(:update_user) { post :update, id: target_user.id, user: params }
     let(:params) { {} }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :member) }
 
     authenticated_as(:admin) do
 
@@ -172,7 +172,7 @@ RSpec.describe Admin::MembersController do
 
   describe 'DELETE destroy' do
     subject { delete :destroy, id: target_user.id }
-    let(:target_user) { FactoryGirl.create(:user) }
+    let(:target_user) { FactoryGirl.create(:user, :member) }
 
     authenticated_as(:admin) do
       it "deletes the user" do


### PR DESCRIPTION
Now if you want to only only admins without a black eye

```ruby
def users_scope
  User.admin.with_a_black_eye
end
```

rather than having to override the index method or somethin