### PR TITLE
Update admin sidebar to be configurable with multiple headings

### DIFF
--- a/app/assets/stylesheets/admin/modules/_sidebar.sass
+++ b/app/assets/stylesheets/admin/modules/_sidebar.sass
@@ -9,6 +9,7 @@ aside[role="complementary"]
   +pad($sidebar-padding)
 
   > h1
+    font-size: 1.3em
     margin: 0
 
   ul

--- a/app/assets/stylesheets/admin/modules/_sidebar.sass
+++ b/app/assets/stylesheets/admin/modules/_sidebar.sass
@@ -31,6 +31,9 @@ aside[role="complementary"]
       a
         color: #fff
 
+  .sidebar-links
+    margin-top: $small-spacing
+
   .mobile-nav
     background-color: transparent
     float: right
@@ -85,9 +88,11 @@ aside[role="complementary"] + main
       padding: 1em
 
     ul
-      display: none
       margin-top: $small-spacing
-      &.is-expanded
+    .sidebar-links
+      display: none
+    .is-expanded
+      .sidebar-links
         display: block
 
     .mobile-nav

--- a/app/views/layouts/admin/_sidebar.html.haml
+++ b/app/views/layouts/admin/_sidebar.html.haml
@@ -1,8 +1,12 @@
 .sidebar-pages
-  %h1.js-nav-toggle{data: {navigation_toggle_target: '#pages-nav'}} User Management
+  %h1.js-nav-toggle{data: {navigation_toggle_target: '#pages-nav'}} Administration
 
   %button.mobile-nav.js-nav-toggle{style: 'display: none;', aria: {label: 'Toggle Pages'}, data: {navigation_toggle_target: '#pages-nav'}}
     %span Menu
 
-  %ul#pages-nav.nav
-    = render "layouts/admin/sidebar_links"
+  #pages-nav.nav
+    .sidebar-links
+      %h2 User Management
+      %ul
+        = active_link_to "Admins", admin_admins_path, wrap_tag: :li
+        = active_link_to "Members", admin_members_path, wrap_tag: :li

--- a/app/views/layouts/admin/_sidebar_links.html.haml
+++ b/app/views/layouts/admin/_sidebar_links.html.haml
@@ -1,2 +1,0 @@
-= active_link_to "Admins", admin_admins_path, wrap_tag: :li
-= active_link_to "Members", admin_members_path, wrap_tag: :li


### PR DESCRIPTION
You can now add headings more easily to the sidebar

![screen shot 2016-03-09 at 12 03 55 pm](https://cloud.githubusercontent.com/assets/296341/13625085/0b77db3a-e5ef-11e5-96af-201dc52f2e38.png)

![screen shot 2016-03-09 at 12 04 00 pm](https://cloud.githubusercontent.com/assets/296341/13625087/0d040e06-e5ef-11e5-8e05-7786eb2b2945.png)

![screen shot 2016-03-09 at 12 04 05 pm](https://cloud.githubusercontent.com/assets/296341/13625088/0ee82a2c-e5ef-11e5-997f-fd941ec24273.png)
