### PR TITLE
Show more appropriate notices when using the Users search

### DIFF
--- a/app/views/admin/admins/index.html.haml
+++ b/app/views/admin/admins/index.html.haml
@@ -3,4 +3,4 @@
   .collection-actions
     = link_to "Add new admin", new_admin_admin_path, class: "btn"
 
-= render partial: "user_results"
+= render partial: "user_results", locals: {new_path_for_user: new_admin_admin_path}

--- a/app/views/admin/members/index.html.haml
+++ b/app/views/admin/members/index.html.haml
@@ -3,4 +3,4 @@
   .collection-actions
     = link_to "Add new member", new_admin_member_path, class: "btn"
 
-= render partial: "user_results"
+= render partial: "user_results", locals: {new_path_for_user: new_admin_member_path}

--- a/app/views/admin/users/_user_results.html.haml
+++ b/app/views/admin/users/_user_results.html.haml
@@ -29,5 +29,5 @@
     %p No users matched your search.
   - else
     %p
-      There are no users,
-      = link_to "click here to create a new user.", new_path_for_user
+      There are no users.
+      = link_to "Create a user now.", new_path_for_user

--- a/app/views/admin/users/_user_results.html.haml
+++ b/app/views/admin/users/_user_results.html.haml
@@ -1,6 +1,8 @@
-= simple_form_for :search, method: :get do |s|
-  = s.input :search_term, label: "Email", placeholder: "Type email here", input_html: { value: (params[:search][:search_term] unless params[:search].blank?) }
-  = s.button :submit, "Search"
+- # Only show the search options if there are users to search for
+- if params[:search].present? || @users.present?
+  = simple_form_for :search, method: :get do |s|
+    = s.input :search_term, label: "Email", placeholder: "Type email here", input_html: { value: (params[:search][:search_term] unless params[:search].blank?) }
+    = s.button :submit, "Search"
 
 - if @users.present?
   %table
@@ -23,4 +25,9 @@
   = paginate @users
 
 - else
-  %p= "No users matched that search"
+  - if params[:search].present?
+    %p No users matched your search.
+  - else
+    %p
+      There are no users,
+      = link_to "click here to create a new user.", new_path_for_user

--- a/spec/features/admin/members/admin_search_member_spec.rb
+++ b/spec/features/admin/members/admin_search_member_spec.rb
@@ -20,7 +20,7 @@ feature 'Admin can search for users by email' do
     scenario "Search with non-matching data" do
       fill_in('Email', with: current_user.email)
       click_button('Search')
-      expect(page).to have_content("No users matched that search")
+      expect(page).to have_content("No users matched your search")
       expect(page).not_to have_content(current_user.email)
     end
   end


### PR DESCRIPTION
When there are no users:

![no_users](https://cloud.githubusercontent.com/assets/296341/13720948/62d1bb66-e852-11e5-97cc-ccfdfc903e5c.png)

When there are some users:

![some_users](https://cloud.githubusercontent.com/assets/296341/13720950/68ac5474-e852-11e5-8667-059f37e5e35e.png)

When your search doesn't return any users:

![no_search_results](https://cloud.githubusercontent.com/assets/296341/13720953/705da402-e852-11e5-9cf3-7023dd2fdf73.png)


