### PR TITLE
Add sane default time zone to template (Australia/Perth)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module TfgTemplate
 
     config.should_seed_application_data = false
     config.should_show_easy_login = false
+
+    config.time_zone = "Australia/Perth"
   end
 end


### PR DESCRIPTION
noticed this was missing in Studium, figured the template requires a better sane default the UTC.