### PR TITLE
Feature: app config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage/*
 config/database.yml
 config/secrets.yml
 config/smtp.yml
+config/settings.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,12 @@ module TfgTemplate
     config.should_show_easy_login = false
 
     config.time_zone = "Australia/Perth"
+
+    # Bring in custom configuration
+    config.x.globals = config_for(:settings)
+  end
+
+  def self.setting
+      Application.config.x.globals
   end
 end

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -1,0 +1,22 @@
+# This file contains application specific settings
+
+# To access any of these, use them like this:
+#   <AppModule>.setting["first_key"]
+
+default: &DEFAULT
+  first_key: "first"
+  second_key: "second"
+  third_key:  "third"
+  flex_key:   "default"
+
+development:
+    <<: *DEFAULT
+
+test:
+    <<: *DEFAULT
+
+staging:
+    <<: *DEFAULT
+
+production:
+    <<: *DEFAULT

--- a/config/smtp.yml.sample
+++ b/config/smtp.yml.sample
@@ -17,4 +17,10 @@ staging:
 
 # Use SendGrid for production
 production:
-  <<: *JAZZ
+    :address              : "smtp.sendgrid.net"
+    :port                 : 587
+    :domain               : 'app+domain'
+    :user_name            : 'user@host'
+    :password             : 'changeme'
+    :authentication       : 'plain'
+    :enable_starttls_auto : true 

--- a/spec/lib/app_settings_spec.rb
+++ b/spec/lib/app_settings_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+class DummyClass
+end
+
+describe TfgTemplate do
+  include TfgTemplate
+
+  it { TfgTemplate.setting["first_key"] == "first" }
+  it { TfgTemplate.setting["second_key"] == "second" }
+end


### PR DESCRIPTION
Add in support for config/settings.yml, where application specific settings can be easily placed and used. That file can be modified per environment if required.

If preferred, we could modify the API to be eg. App.setting.first_key rather than setting["first_key"]

NOTE: I've also slipped in an update to smtp.yml.sample to template using SendGrid in production as part of this PR, but it's irrelevant to the feature.