### PR TITLE
Add health_check for uptime monitoring and smoke testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'active_link_to'
 gem 'responders'
 gem 'uri_query_merger'
 
+# Monitoring & Ops
+gem 'health_check'
+
 group :development do
   gem 'better_errors'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    health_check (1.5.1)
+      rails (>= 2.3.0)
     highline (1.7.8)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
@@ -307,6 +309,7 @@ DEPENDENCIES
   factory_girl_rails
   ffaker
   haml-rails
+  health_check
   jquery-rails
   jquery-timepicker-rails
   kaminari

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,22 @@
+# Configure our /health_check endpoint do know the app is actually running ok
+
+HealthCheck.setup do |config|
+
+  # Text output on success
+  config.success = "success"
+
+  config.standard_checks = [ 'database', 'migrations', 'custom' ]
+  config.full_checks = [ 'database', 'migrations', 'custom', 'email', 'cache' ]
+  
+  config.smtp_timeout = 30.0
+
+  config.http_status_for_error_text = 503
+  config.http_status_for_error_object = 503
+
+  # We can add any custom checks here. Method must return a blank string for ok
+  # or an error message
+  #
+  #config.add_custom_check do
+  #   CustomClass.perform_health_check 
+  #end
+end

--- a/spec/requests/health_check.rb
+++ b/spec/requests/health_check.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "HealthCheck API" do
+
+    it 'responds to a check request' do
+        get '/health_check/standard.json'
+        json_body = JSON.parse(response.body)
+        expect(response).to be_success
+    end
+
+    it 'returns a failure for an unknown check' do
+        get '/health_check/unknown.json'
+        json_body = JSON.parse(response.body)
+        expect(response).to have_http_status(503)
+    end
+end


### PR DESCRIPTION
This allows us to query the application to see if it is actually up (i.e., can answer queries, connect to the DB etc)  Besides up monitoring, it also provides a useful (scriptable) smoke-test post deploy.