### PR TITLE
Add support for Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'shoulda-matchers'
+  gem 'timecop'
 end
 
 group :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -334,6 +335,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   tfg_cap!
+  timecop
   uglifier
   uri_query_merger
   web-console

--- a/spec/support/configuration/timecop.rb
+++ b/spec/support/configuration/timecop.rb
@@ -1,0 +1,28 @@
+# You can freeze time using Timecop in one of two ways:
+#
+# 1. Without a specific time (uses Time.zone.now):
+#
+#   it "runs your test", :freeze_time do
+#   end
+#
+# 2. With a specific time:
+#
+#   it "runs your test", freeze_time: Time.zone.parse("11:00pm") do
+#   end
+#
+RSpec.configure do |config|
+
+  config.around(:each) do |ex|
+    freeze_time = ex.example.metadata[:freeze_time]
+
+    if freeze_time.present?
+      freeze_time_at = freeze_time.kind_of?(Time) ? freeze_time : Time.zone.now.change(nsec: 0)
+      Timecop.freeze(freeze_time_at) do
+        ex.run
+      end
+    else
+      ex.run
+    end
+  end
+
+end


### PR DESCRIPTION
Borrowed something awesome ya boy @osiro did in CV!

```ruby
# You can freeze time using Timecop in one of two ways:
#
# 1. Without a specific time (uses Time.zone.now):
#
#   it "runs your test", :freeze_time do
#   end
#
# 2. With a specific time:
#
#   it "runs your test", freeze_time: Time.zone.parse("11:00pm") do
#   end
#
```

Thanks @osiro!