### PR TITLE
Fix #137: Use consistent terminology for delete action

### DIFF
--- a/app/helpers/admin/resource_action_helper.rb
+++ b/app/helpers/admin/resource_action_helper.rb
@@ -1,0 +1,13 @@
+module Admin::ResourceActionHelper
+
+  def link_to_archive_resource(path, resource_name, html_options={})
+    html_options = html_options.reverse_merge({
+      class: "btn btn-small btn-danger",
+      data: {confirm: t("actions.archive_prompt.confirmation", name: resource_name)},
+      method: :delete,
+    })
+
+    link_to(t("actions.archive_prompt.label"), path, html_options)
+  end
+
+end

--- a/app/views/admin/users/_user_results.html.haml
+++ b/app/views/admin/users/_user_results.html.haml
@@ -24,7 +24,7 @@
               - if can?(:edit, user)
                 = link_to "Edit", edit_path_for_user(user), class: "btn btn-small"
               - if can?(:destroy, user)
-                = link_to "Delete", delete_path_for_user(user), method: :delete, data: { confirm: "Are you sure you want to delete '#{user.full_name}'?" }, class: "btn btn-small"
+                = link_to_archive_resource(delete_path_for_user(user), user.full_name)
   = paginate @users
 
 - elsif params[:q].present?

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -1,0 +1,8 @@
+en:
+  actions:
+    archive_prompt:
+      label: "Archive"
+      confirmation: "Are you sure you want to archive %{name}?"
+    delete_prompt:
+      label: "Delete"
+      confirmation: "Are you sure you want to delete %{name}?"

--- a/spec/features/admin/admins/archive_admin_spec.rb
+++ b/spec/features/admin/admins/archive_admin_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Admin can delete an existing User' do
+feature 'Admin can archive an existing User' do
 
   signed_in_as(:admin) do
     let!(:target_user) { FactoryGirl.create(:user, :admin, email: "something@nothing.com") }
@@ -10,9 +10,9 @@ feature 'Admin can delete an existing User' do
       click_sidemenu_option("Admins")
     end
 
-    scenario 'Admin can delete user' do
+    scenario do
       within_row(target_user.email) do
-        click_link("Delete")
+        click_link("Archive")
       end
 
       # User should be deleted

--- a/spec/features/admin/members/archive_member_spec.rb
+++ b/spec/features/admin/members/archive_member_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Admin can delete an existing User' do
+feature 'Admin can archive an existing User' do
 
   signed_in_as(:admin) do
     let!(:target_user) { FactoryGirl.create(:user, email: "something@nothing.com") }
@@ -10,9 +10,9 @@ feature 'Admin can delete an existing User' do
       click_sidemenu_option("Members")
     end
 
-    scenario 'Admin can delete user' do
+    scenario do
       within_row(target_user.email) do
-        click_link("Delete")
+        click_link("Archive")
       end
 
       # User should be deleted

--- a/spec/helpers/admin/resource_action_helper_spec.rb
+++ b/spec/helpers/admin/resource_action_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Admin::ResourceActionHelper do
+
+  describe "#link_to_archive_resource" do
+    subject(:link) { Nokogiri.parse(link_html).children.first }
+    let(:link_html) { helper.link_to_archive_resource("my_path", "Jordan") }
+
+    it "sets the href correctly" do
+      expect(link["href"]).to eq("my_path")
+    end
+
+    it "sets a data-confirm message" do
+      expect(link["data-confirm"]).to eq("Are you sure you want to archive Jordan?")
+    end
+
+    specify { expect(link.content).to eq("Archive") }
+  end
+
+end


### PR DESCRIPTION
![screen shot 2016-08-23 at 6 03 38 pm](https://cloud.githubusercontent.com/assets/296341/17888092/f283df70-695b-11e6-9784-dd609368513f.png)
