### PR TITLE
Fix #141: Remember path the user tried to sign in to

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ protected
 
   # Provided by Devise
   def after_sign_in_path_for(resource)
-    AfterSignInPath.new(resource).to_s
+    stored_location_for(:user) || AfterSignInPath.new(resource).to_s
   end
 
 # Strong Parameters

--- a/spec/features/authentication/remember_pre_authentication_path_spec.rb
+++ b/spec/features/authentication/remember_pre_authentication_path_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature "user should be redirected to same path they tried to access when unauthenticated" do
+
+  let(:user) { FactoryGirl.create(:user, :admin) }
+
+  scenario do
+    visit(admin_admins_path)
+
+    expect(page).to have_flash(:alert, "You need to sign in or sign up before continuing.")
+    expect(current_path).not_to eq(admin_admins_path)
+
+    fill_in("Email", with: user.email)
+    fill_in("Password", with: "password")
+    click_button("Sign in")
+
+    expect(current_path).to eq(admin_admins_path)
+  end
+
+end


### PR DESCRIPTION
Instead of always redirecting you in to your dashboard, you get redirected to the url you tried to access when you were unauthenticated