### PR TITLE
Remove autocomplete on new users

### DIFF
--- a/app/views/admin/admins/_form.html.haml
+++ b/app/views/admin/admins/_form.html.haml
@@ -3,7 +3,7 @@
   = f.input :given_names, input_html: {maxlength: User::MAX_NAME_LENGTH}
   = f.input :family_name, input_html: {maxlength: User::MAX_NAME_LENGTH}
   = f.input :email
-  = f.input :password, hint: "Minimum is #{Rails.configuration.devise.password_length.min} characters"
+  = f.input :password, hint: "Minimum is #{Rails.configuration.devise.password_length.min} characters", input_html: {autocomplete: "new-password"}
 
   .form-actions
     = f.button :submit

--- a/app/views/admin/members/_form.html.haml
+++ b/app/views/admin/members/_form.html.haml
@@ -3,7 +3,7 @@
   = f.input :given_names, input_html: {maxlength: User::MAX_NAME_LENGTH}
   = f.input :family_name, input_html: {maxlength: User::MAX_NAME_LENGTH}
   = f.input :email
-  = f.input :password, hint: "Minimum is #{Rails.configuration.devise.password_length.min} characters"
+  = f.input :password, hint: "Minimum is #{Rails.configuration.devise.password_length.min} characters", input_html: {autocomplete: "new-password"}
 
   .form-actions
     = f.button :submit


### PR DESCRIPTION
There is never a case where someone is going to want to autocomplete the email and password for a new user.

Using this solution:

http://stackoverflow.com/a/38961567/3029916

Confirmed that autocomplete is not happening in Chrome, Safari, and Firefox