### PR TITLE
Improve admin page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,13 @@
 module ApplicationHelper
 
   def current_page_title(object=nil)
-    page_title!(t('.title', label: object))
+    if can?(:manage, :all)
+      title_type = :admin
+    else
+      title_type = :default
+    end
+
+    page_title!(t('.title', label: object), title_type)
   end
 
 end

--- a/config/initializers/page_title_helper.rb
+++ b/config/initializers/page_title_helper.rb
@@ -4,3 +4,4 @@ PageTitleHelper.formats[:default] = ":title – :app"
 # add custom format aliases (which can be used with page_title(format: :page))
 PageTitleHelper.formats[:page] = ":title"
 PageTitleHelper.formats[:public_home] = ":app - :title"
+PageTitleHelper.formats[:admin] = ":title | :app Admin"

--- a/config/locales/page_titles.yml
+++ b/config/locales/page_titles.yml
@@ -18,7 +18,7 @@ en:
 
     admins:
       index:
-        title: "Admin Management"
+        title: "Admins"
       new:
         title: "New Admin"
       edit:
@@ -26,7 +26,7 @@ en:
 
     members:
       index:
-        title: "Member Management"
+        title: "Members"
       new:
         title: "New Member"
       edit:


### PR DESCRIPTION
Matching title and link to page...
<img width="466" alt="screen shot 2016-11-17 at 23 10 25" src="https://cloud.githubusercontent.com/assets/2037851/20394599/0cb971c2-ad1b-11e6-9ab3-5d20df7390be.png">

You can now tell what pages you visited in-/outside admin section:

![image](https://cloud.githubusercontent.com/assets/2037851/20394624/2a588a7e-ad1b-11e6-855d-07e955d16db3.png)
